### PR TITLE
Add import capabilities

### DIFF
--- a/resource_cabot_check_graphite.go
+++ b/resource_cabot_check_graphite.go
@@ -37,6 +37,9 @@ func resourceCabotCheckGraphite() *schema.Resource {
 		Read:   resourceCabotCheckGraphiteRead,
 		Update: resourceCabotCheckGraphiteUpdate,
 		Delete: resourceCabotCheckGraphiteDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: CombineWithBaseCheckSchema(s),
 	}

--- a/resource_cabot_check_http.go
+++ b/resource_cabot_check_http.go
@@ -46,6 +46,9 @@ func resourceCabotCheckHTTP() *schema.Resource {
 		Read:   resourceCabotCheckHTTPRead,
 		Update: resourceCabotCheckHTTPUpdate,
 		Delete: resourceCabotCheckHTTPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: CombineWithBaseCheckSchema(s),
 	}

--- a/resource_cabot_check_icmp.go
+++ b/resource_cabot_check_icmp.go
@@ -12,6 +12,9 @@ func resourceCabotCheckICMP() *schema.Resource {
 		Read:   resourceCabotCheckICMPRead,
 		Update: resourceCabotCheckICMPUpdate,
 		Delete: resourceCabotCheckICMPDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: baseCheckSchema,
 	}

--- a/resource_cabot_check_jenkins.go
+++ b/resource_cabot_check_jenkins.go
@@ -19,6 +19,9 @@ func resourceCabotCheckJenkins() *schema.Resource {
 		Read:   resourceCabotCheckJenkinsRead,
 		Update: resourceCabotCheckJenkinsUpdate,
 		Delete: resourceCabotCheckJenkinsDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: CombineWithBaseCheckSchema(s),
 	}

--- a/resource_cabot_instance.go
+++ b/resource_cabot_instance.go
@@ -12,6 +12,9 @@ func resourceCabotInstance() *schema.Resource {
 		Read:   resourceCabotInstanceRead,
 		Update: resourceCabotInstanceUpdate,
 		Delete: resourceCabotInstanceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"address": &schema.Schema{

--- a/resource_cabot_service.go
+++ b/resource_cabot_service.go
@@ -12,6 +12,9 @@ func resourceCabotService() *schema.Resource {
 		Read:   resourceCabotServiceRead,
 		Update: resourceCabotServiceUpdate,
 		Delete: resourceCabotServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"alerts": &schema.Schema{


### PR DESCRIPTION
From https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_importer.go

    // ImportStatePassthrough is an implementation of StateFunc that can be
    // used to simply pass the ID directly through. This should be used only
    // in the case that an ID-only refresh is possible.

As far as I know all our resources are ID-only refreshable, so the pass
through importer should work fine