### PR TITLE
Change TypeList to TypeSet (take 2)

### DIFF
--- a/resource_cabot_instance.go
+++ b/resource_cabot_instance.go
@@ -66,17 +66,17 @@ func getInstanceFromResourceData(d *schema.ResourceData) *cabot.Instance {
 		Name:          d.Get("name").(string),
 	}
 
-	alerts := d.Get("alerts").([]interface{})
+	alerts := d.Get("alerts").(*schema.Set).List()
 	for _, alert := range alerts {
 		instanceRequest.Alerts = append(instanceRequest.Alerts, alert.(int))
 	}
 
-	statusChecks := d.Get("status_checks").([]interface{})
+	statusChecks := d.Get("status_checks").(*schema.Set).List()
 	for _, check := range statusChecks {
 		instanceRequest.StatusChecks = append(instanceRequest.StatusChecks, check.(int))
 	}
 
-	usersToNotify := d.Get("users_to_notify").([]interface{})
+	usersToNotify := d.Get("users_to_notify").(*schema.Set).List()
 	for _, user := range usersToNotify {
 		instanceRequest.UsersToNotify = append(instanceRequest.UsersToNotify, user.(int))
 	}

--- a/resource_cabot_service.go
+++ b/resource_cabot_service.go
@@ -73,23 +73,23 @@ func getServiceFromResourceData(d *schema.ResourceData) *cabot.Service {
 		URL:           d.Get("url").(string),
 	}
 
-	alerts := d.Get("alerts").([]interface{})
+	alerts := d.Get("alerts").(*schema.Set).List()
 	for _, alert := range alerts {
 		serviceRequest.Alerts = append(serviceRequest.Alerts, alert.(int))
 	}
 
-	instances := d.Get("instances").([]interface{})
+	instances := d.Get("instances").(*schema.Set).List()
 	for _, instance := range instances {
 		serviceRequest.Instances = append(serviceRequest.Instances, instance.(int))
 	}
 
 	// TODO: sort
-	statusChecks := d.Get("status_checks").([]interface{})
+	statusChecks := d.Get("status_checks").(*schema.Set).List()
 	for _, check := range statusChecks {
 		serviceRequest.StatusChecks = append(serviceRequest.StatusChecks, check.(int))
 	}
 
-	usersToNotify := d.Get("users_to_notify").([]interface{})
+	usersToNotify := d.Get("users_to_notify").(*schema.Set).List()
 	for _, user := range usersToNotify {
 		serviceRequest.UsersToNotify = append(serviceRequest.UsersToNotify, user.(int))
 	}


### PR DESCRIPTION
This fixed re-ordering bugs where with no changes it tries to change
the order of a resource's children