### PR TITLE
Add resource retry for all resources read method

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	"github.com/hashicorp/terraform/plugin"
+	"time"
+)
+
+const (
+	DEFAULT_RETRY_TIMEOUT = 1 * time.Minute
+	DEFAULT_GRACE_PERIOD  = 2 * time.Second
 )
 
 func main() {

--- a/resource_cabot_check_graphite.go
+++ b/resource_cabot_check_graphite.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/mrsaints/go-cabot/cabot"
 	"strconv"
+	"time"
 )
 
 func resourceCabotCheckGraphite() *schema.Resource {
@@ -73,19 +75,24 @@ func resourceCabotCheckGraphiteRead(d *schema.ResourceData, meta interface{}) er
 	client := meta.(*cabot.Client)
 
 	id, _ := strconv.Atoi(d.Id())
-	check, err := client.GraphiteChecks.Get(id)
-	if err != nil {
-		return err
-	}
 
-	d.SetId(strconv.Itoa(check.ID))
-	setResourceDataForStatusCheck(d, check.StatusCheck)
-	d.Set("metric", check.Metric)
-	d.Set("check_type", check.CheckType)
-	d.Set("value", check.Value)
-	d.Set("expected_num_hosts", check.ExpectedNumHosts)
-	d.Set("allowed_num_failures", check.AllowedNumFailures)
-	return nil
+	return resource.Retry(DEFAULT_RETRY_TIMEOUT, func() *resource.RetryError {
+		check, err := client.GraphiteChecks.Get(id)
+		if err != nil {
+			time.Sleep(DEFAULT_GRACE_PERIOD)
+			return resource.RetryableError(err)
+		}
+
+		d.SetId(strconv.Itoa(check.ID))
+		setResourceDataForStatusCheck(d, check.StatusCheck)
+		d.Set("metric", check.Metric)
+		d.Set("check_type", check.CheckType)
+		d.Set("value", check.Value)
+		d.Set("expected_num_hosts", check.ExpectedNumHosts)
+		d.Set("allowed_num_failures", check.AllowedNumFailures)
+
+		return nil
+	})
 }
 
 func resourceCabotCheckGraphiteUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
There are instances where a state refresh may fail because we are
hitting the API too hard. This is especially the case when there
are a lot of Cabot Terraform config.

This commit resolves the problem by adding resource retry for all
the read methods. A grace period is also added so that we do not
retry immediately.

---

Give this a try locally @frankh. I think it does slow the refresh down, but not by a lot.
